### PR TITLE
wireshark-common package reconfigured with dpkg

### DIFF
--- a/scripts/vm_setup_script.sh
+++ b/scripts/vm_setup_script.sh
@@ -9,6 +9,10 @@ sudo apt install xfce4 -y
 # Start desktop environment
 sudo startxfce4 &
 
+# Installing and configuring wireshark-common to avoid the confirmation screen
+sudo apt install wireshark-common
+yes | sudo dpkg reconfigure wireshark-common
+
 # Enough of black on white term
 sudo apt install terminator -y
 
@@ -17,5 +21,5 @@ sudo apt install docker.io -y
 docker pull alpine
 docker pull frrouting/frr
 
-# GNS3
+# GNS3 (confirmation screen should now be avoided)
 sudo apt install gns3 -y

--- a/scripts/vm_setup_script.sh
+++ b/scripts/vm_setup_script.sh
@@ -9,10 +9,6 @@ sudo apt install xfce4 -y
 # Start desktop environment
 sudo startxfce4 &
 
-# Installing and configuring wireshark-common to avoid the confirmation screen
-sudo apt install wireshark-common
-yes | sudo dpkg reconfigure wireshark-common
-
 # Enough of black on white term
 sudo apt install terminator -y
 
@@ -20,6 +16,3 @@ sudo apt install terminator -y
 sudo apt install docker.io -y
 docker pull alpine
 docker pull frrouting/frr
-
-# GNS3 (confirmation screen should now be avoided)
-sudo apt install gns3 -y


### PR DESCRIPTION
wireshark-common package is now pre-installed and reconfigured before installing gns3. This works fine on my machine (Ubuntu 22.04.1). If it isn't the case for everyone, we will simply install gns3 in the vm manually at startup for corrections.